### PR TITLE
Allows to query the union all of graphs as the default graph

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -11,7 +11,7 @@
 //! ```
 //! use rudf::model::*;
 //! use rudf::{Repository, RepositoryConnection, MemoryRepository, Result};
-//! use crate::rudf::sparql::PreparedQuery;
+//! use crate::rudf::sparql::{PreparedQuery, QueryOptions};
 //! use rudf::sparql::QueryResult;
 //!
 //! let repository = MemoryRepository::default();
@@ -27,7 +27,7 @@
 //! assert_eq!(vec![quad], results.unwrap());
 //!
 //! // SPARQL query
-//! let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", None).unwrap();
+//! let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", QueryOptions::default()).unwrap();
 //! let results = prepared_query.exec().unwrap();
 //! if let QueryResult::Bindings(results) = results {
 //!     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -1,5 +1,5 @@
 use crate::model::*;
-use crate::sparql::PreparedQuery;
+use crate::sparql::{PreparedQuery, QueryOptions};
 use crate::{DatasetSyntax, GraphSyntax, Result};
 use std::io::BufRead;
 
@@ -14,7 +14,7 @@ use std::io::BufRead;
 /// ```
 /// use rudf::model::*;
 /// use rudf::{Repository, RepositoryConnection, MemoryRepository, Result};
-/// use crate::rudf::sparql::PreparedQuery;
+/// use crate::rudf::sparql::{PreparedQuery, QueryOptions};
 /// use rudf::sparql::QueryResult;
 ///
 /// let repository = MemoryRepository::default();
@@ -30,7 +30,7 @@ use std::io::BufRead;
 /// assert_eq!(vec![quad], results.unwrap());
 ///
 /// // SPARQL query
-/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", None).unwrap();
+/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", QueryOptions::default()).unwrap();
 /// let results = prepared_query.exec().unwrap();
 /// if let QueryResult::Bindings(results) = results {
 ///     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));
@@ -64,7 +64,7 @@ pub trait RepositoryConnection: Clone {
     /// ```
     /// use rudf::model::*;
     /// use rudf::{Repository, RepositoryConnection, MemoryRepository};
-    /// use rudf::sparql::PreparedQuery;
+    /// use rudf::sparql::{PreparedQuery, QueryOptions};
     /// use rudf::sparql::QueryResult;
     ///
     /// let repository = MemoryRepository::default();
@@ -75,13 +75,13 @@ pub trait RepositoryConnection: Clone {
     /// connection.insert(&Quad::new(ex.clone(), ex.clone(), ex.clone(), None));
     ///
     /// // SPARQL query
-    /// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", None).unwrap();
+    /// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", QueryOptions::default()).unwrap();
     /// let results = prepared_query.exec().unwrap();
     /// if let QueryResult::Bindings(results) = results {
     ///     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));
     /// }
     /// ```
-    fn prepare_query(&self, query: &str, base_iri: Option<&str>) -> Result<Self::PreparedQuery>;
+    fn prepare_query(&self, query: &str, options: QueryOptions) -> Result<Self::PreparedQuery>;
 
     /// Retrieves quads with a filter on each quad component
     ///

--- a/lib/src/store/memory.rs
+++ b/lib/src/store/memory.rs
@@ -14,7 +14,7 @@ use std::sync::{PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// use rudf::model::*;
 /// use rudf::{Repository, RepositoryConnection, MemoryRepository, Result};
 /// use crate::rudf::sparql::PreparedQuery;
-/// use rudf::sparql::QueryResult;
+/// use rudf::sparql::{QueryResult, QueryOptions};
 ///
 /// let repository = MemoryRepository::default();
 /// let mut connection = repository.connection().unwrap();
@@ -29,7 +29,7 @@ use std::sync::{PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// assert_eq!(vec![quad], results.unwrap());
 ///
 /// // SPARQL query
-/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", None).unwrap();
+/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", QueryOptions::default()).unwrap();
 /// let results = prepared_query.exec().unwrap();
 /// if let QueryResult::Bindings(results) = results {
 ///     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));

--- a/lib/src/store/mod.rs
+++ b/lib/src/store/mod.rs
@@ -10,7 +10,7 @@ pub use crate::store::memory::MemoryRepository;
 pub use crate::store::rocksdb::RocksDbRepository;
 
 use crate::model::*;
-use crate::sparql::SimplePreparedQuery;
+use crate::sparql::{QueryOptions, SimplePreparedQuery};
 use crate::store::numeric_encoder::*;
 use crate::{DatasetSyntax, GraphSyntax, RepositoryConnection, Result};
 use rio_api::parser::{QuadsParser, TriplesParser};
@@ -71,8 +71,8 @@ impl<S: StoreConnection> From<S> for StoreRepositoryConnection<S> {
 impl<S: StoreConnection> RepositoryConnection for StoreRepositoryConnection<S> {
     type PreparedQuery = SimplePreparedQuery<S>;
 
-    fn prepare_query(&self, query: &str, base_iri: Option<&str>) -> Result<SimplePreparedQuery<S>> {
-        SimplePreparedQuery::new(self.inner.clone(), query, base_iri) //TODO: avoid clone
+    fn prepare_query(&self, query: &str, options: QueryOptions) -> Result<SimplePreparedQuery<S>> {
+        SimplePreparedQuery::new(self.inner.clone(), query, options) //TODO: avoid clone
     }
 
     fn quads_for_pattern<'a>(

--- a/lib/src/store/rocksdb.rs
+++ b/lib/src/store/rocksdb.rs
@@ -24,7 +24,7 @@ use std::str;
 /// ```ignored
 /// use rudf::model::*;
 /// use rudf::{Repository, RepositoryConnection, RocksDbRepository, Result};
-/// use crate::rudf::sparql::PreparedQuery;
+/// use crate::rudf::sparql::{PreparedQuery, QueryOptions};
 /// use rudf::sparql::QueryResult;
 ///
 /// let repository = RocksDbRepository::open("example.db").unwrap();
@@ -40,7 +40,7 @@ use std::str;
 /// assert_eq!(vec![quad], results.unwrap());
 ///
 /// // SPARQL query
-/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", None).unwrap();
+/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", QueryOptions::default()).unwrap();
 /// let results = prepared_query.exec().unwrap();
 /// if let QueryResult::Bindings(results) = results {
 ///     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));

--- a/lib/tests/sparql_test_cases.rs
+++ b/lib/tests/sparql_test_cases.rs
@@ -4,7 +4,7 @@ use rayon::prelude::*;
 use rudf::model::vocab::rdf;
 use rudf::model::vocab::rdfs;
 use rudf::model::*;
-use rudf::sparql::PreparedQuery;
+use rudf::sparql::{PreparedQuery, QueryOptions};
 use rudf::sparql::{Query, QueryResult, QueryResultSyntax};
 use rudf::{GraphSyntax, MemoryRepository, Repository, RepositoryConnection, Result};
 use std::fmt;
@@ -158,7 +158,7 @@ fn sparql_w3c_query_evaluation_testsuite() -> Result<()> {
             }
             match repository
                 .connection()?
-                .prepare_query(&read_file_to_string(&test.query)?, Some(&test.query))
+                .prepare_query(&read_file_to_string(&test.query)?, QueryOptions::default().with_base_iri(&test.query))
             {
                 Err(error) => Err(format_err!(
                     "Failure to parse query of {} with error: {}",

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -4,8 +4,7 @@ use clap::ArgMatches;
 use rouille::input::priority_header_preferred;
 use rouille::url::form_urlencoded;
 use rouille::{content_encoding, start_server, Request, Response};
-use rudf::sparql::QueryResult;
-use rudf::sparql::{PreparedQuery, QueryResultSyntax};
+use rudf::sparql::{PreparedQuery, QueryOptions, QueryResult, QueryResultSyntax};
 use rudf::{
     DatasetSyntax, FileSyntax, GraphSyntax, MemoryRepository, Repository, RepositoryConnection,
     RocksDbRepository,
@@ -149,7 +148,7 @@ fn evaluate_sparql_query<R: RepositoryConnection>(
     request: &Request,
 ) -> Response {
     //TODO: stream
-    match connection.prepare_query(query, None) {
+    match connection.prepare_query(query, QueryOptions::default()) {
         Ok(query) => {
             let results = query.exec().unwrap();
             if let QueryResult::Graph(_) = results {


### PR DESCRIPTION
Introduces `QueryOptions`.

`QueryOptions` is given to the `prepare` method in order to put in it things like the base IRI.

It uses the "builder" pattern:
- The default options are given by `QueryOptions::default()`
- There are multiple setters to override the default options like `fn with_base_iri(mut self, base_iri: &'a str) -> Self`

This way it solves the "empty `ServiceHandler` problem": the default option would be no ServiceHandler and, if the library user want to set a `ServiceHandler` they have to give a not empty one.