### PR TITLE
Service query options

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -27,8 +27,9 @@
 //! assert_eq!(vec![quad], results.unwrap());
 //!
 //! // SPARQL query
-//! let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", QueryOptions::default()).unwrap();
-//! let results = prepared_query.exec().unwrap();
+//! let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", None).unwrap();
+//! let options = QueryOptions::default();
+//! let results = prepared_query.exec(&options).unwrap();
 //! if let QueryResult::Bindings(results) = results {
 //!     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));
 //! }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -44,7 +44,7 @@ pub use failure::Error;
 pub type Result<T> = ::std::result::Result<T, failure::Error>;
 pub use crate::repository::Repository;
 pub use crate::repository::RepositoryConnection;
-pub use crate::store::MemoryRepository;
+pub use crate::store::{MemoryRepository, MemoryRepositoryConnection};
 #[cfg(feature = "rocksdb")]
 pub use crate::store::RocksDbRepository;
 pub use crate::syntax::DatasetSyntax;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -44,7 +44,7 @@ pub use failure::Error;
 pub type Result<T> = ::std::result::Result<T, failure::Error>;
 pub use crate::repository::Repository;
 pub use crate::repository::RepositoryConnection;
-pub use crate::store::{MemoryRepository, MemoryRepositoryConnection};
+pub use crate::store::MemoryRepository;
 #[cfg(feature = "rocksdb")]
 pub use crate::store::RocksDbRepository;
 pub use crate::syntax::DatasetSyntax;

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -1,6 +1,7 @@
 use crate::model::*;
 use crate::sparql::{GraphPattern, PreparedQuery, QueryOptions};
 use crate::{DatasetSyntax, GraphSyntax, Result};
+use rio_api::iri::Iri;
 use std::io::BufRead;
 
 /// A `Repository` stores a [RDF dataset](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset)
@@ -81,7 +82,13 @@ pub trait RepositoryConnection: Clone {
     ///     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));
     /// }
     /// ```
-    fn prepare_query<'a>(&'a self, query: &str, options: &'a QueryOptions<'a>) -> Result<Self::PreparedQuery>;
+    fn prepare_query<'a>(&'a self, query: &str, base_iri: Option<&'a str>) -> Result<Self::PreparedQuery>;
+
+
+    fn prepare_query_from_pattern<'a>(
+        &'a self,
+        graph_pattern: &'a GraphPattern,
+    ) -> Result<Self::PreparedQuery>;
 
     /// Retrieves quads with a filter on each quad component
     ///
@@ -111,13 +118,6 @@ pub trait RepositoryConnection: Clone {
     ) -> Box<dyn Iterator<Item = Result<Quad>> + 'a>
     where
         Self: 'a;
-
-    fn prepare_query_from_pattern<'a>(
-        &'a self,
-        graph_pattern: &'a GraphPattern,
-        options: &'a QueryOptions<'a>
-    ) -> Result<Self::PreparedQuery>;
-
 
     /// Loads a graph file (i.e. triples) into the repository
     ///

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -1,7 +1,6 @@
 use crate::model::*;
-use crate::sparql::{GraphPattern, PreparedQuery, QueryOptions};
+use crate::sparql::{GraphPattern, PreparedQuery};
 use crate::{DatasetSyntax, GraphSyntax, Result};
-use rio_api::iri::Iri;
 use std::io::BufRead;
 
 /// A `Repository` stores a [RDF dataset](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset)

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -1,5 +1,5 @@
 use crate::model::*;
-use crate::sparql::{PreparedQuery, QueryOptions};
+use crate::sparql::{GraphPattern, PreparedQuery, QueryOptions};
 use crate::{DatasetSyntax, GraphSyntax, Result};
 use std::io::BufRead;
 
@@ -81,7 +81,7 @@ pub trait RepositoryConnection: Clone {
     ///     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));
     /// }
     /// ```
-    fn prepare_query(&self, query: &str, options: QueryOptions) -> Result<Self::PreparedQuery>;
+    fn prepare_query<'a>(&'a self, query: &str, options: &'a QueryOptions<'a>) -> Result<Self::PreparedQuery>;
 
     /// Retrieves quads with a filter on each quad component
     ///
@@ -111,6 +111,13 @@ pub trait RepositoryConnection: Clone {
     ) -> Box<dyn Iterator<Item = Result<Quad>> + 'a>
     where
         Self: 'a;
+
+    fn prepare_query_from_pattern<'a>(
+        &'a self,
+        graph_pattern: &'a GraphPattern,
+        options: &'a QueryOptions<'a>
+    ) -> Result<Self::PreparedQuery>;
+
 
     /// Loads a graph file (i.e. triples) into the repository
     ///

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -85,7 +85,7 @@ pub trait RepositoryConnection: Clone {
     /// ```
     fn prepare_query<'a>(&'a self, query: &str, base_iri: Option<&'a str>) -> Result<Self::PreparedQuery>;
 
-
+    /// This is similar to `prepare_query`, but useful if a SPARQL query has already been parsed, which is the case when building `ServiceHandler`s for federated queries with `SERVICE` clauses. For examples, look in the tests.
     fn prepare_query_from_pattern<'a>(
         &'a self,
         graph_pattern: &'a GraphPattern,

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -30,8 +30,9 @@ use std::io::BufRead;
 /// assert_eq!(vec![quad], results.unwrap());
 ///
 /// // SPARQL query
-/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", QueryOptions::default()).unwrap();
-/// let results = prepared_query.exec().unwrap();
+/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", None).unwrap();
+/// let options = QueryOptions::default();
+/// let results = prepared_query.exec(&options).unwrap();
 /// if let QueryResult::Bindings(results) = results {
 ///     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));
 /// }
@@ -75,8 +76,9 @@ pub trait RepositoryConnection: Clone {
     /// connection.insert(&Quad::new(ex.clone(), ex.clone(), ex.clone(), None));
     ///
     /// // SPARQL query
-    /// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", QueryOptions::default()).unwrap();
-    /// let results = prepared_query.exec().unwrap();
+    /// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", None).unwrap();
+    /// let options = QueryOptions::default();
+    /// let results = prepared_query.exec(&options).unwrap();
     /// if let QueryResult::Bindings(results) = results {
     ///     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));
     /// }
@@ -87,6 +89,7 @@ pub trait RepositoryConnection: Clone {
     fn prepare_query_from_pattern<'a>(
         &'a self,
         graph_pattern: &'a GraphPattern,
+        base_iri: Option<&str>,
     ) -> Result<Self::PreparedQuery>;
 
     /// Retrieves quads with a filter on each quad component

--- a/lib/src/sparql/eval.rs
+++ b/lib/src/sparql/eval.rs
@@ -1662,6 +1662,7 @@ impl<'a, S: StoreConnection + 'a> SimpleEvaluator<S> {
         )
     }
 
+    // this is used to encode results froma BindingIterator into an EncodedTuplesIterator. This happens when SERVICE clauses are evaluated
     fn encode_bindings<'b>(
         &'b self,
         variables: &'b [Variable],

--- a/lib/src/sparql/eval.rs
+++ b/lib/src/sparql/eval.rs
@@ -130,6 +130,13 @@ impl<'a, S: StoreConnection + 'a> SimpleEvaluator<S> {
         match node {
             PlanNode::Init => Box::new(once(Ok(from))),
             PlanNode::StaticBindings { tuples } => Box::new(tuples.iter().cloned().map(Ok)),
+            PlanNode::Service {
+                child,
+                ..
+            } => {
+                println!("Service!");
+                self.eval_plan(&*child, from, options)
+            },
             PlanNode::QuadPatternJoin {
                 child,
                 subject,

--- a/lib/src/sparql/mod.rs
+++ b/lib/src/sparql/mod.rs
@@ -64,7 +64,7 @@ impl<'a, S: StoreConnection + 'a> SimplePreparedQuery<S> {
             QueryVariants::Select {
                 algebra,
                 dataset: _,
-                base_iri,
+                ..
             } => {
                 let (plan, variables) = PlanBuilder::build(dataset.encoder(), &algebra)?;
                 SimplePreparedQueryAction::Select {
@@ -76,7 +76,7 @@ impl<'a, S: StoreConnection + 'a> SimplePreparedQuery<S> {
             QueryVariants::Ask {
                 algebra,
                 dataset: _,
-                base_iri,
+                ..
             } => {
                 let (plan, _) = PlanBuilder::build(dataset.encoder(), &algebra)?;
                 SimplePreparedQueryAction::Ask {
@@ -88,7 +88,7 @@ impl<'a, S: StoreConnection + 'a> SimplePreparedQuery<S> {
                 construct,
                 algebra,
                 dataset: _,
-                base_iri,
+                ..
             } => {
                 let (plan, variables) = PlanBuilder::build(dataset.encoder(), &algebra)?;
                 SimplePreparedQueryAction::Construct {
@@ -104,7 +104,7 @@ impl<'a, S: StoreConnection + 'a> SimplePreparedQuery<S> {
             QueryVariants::Describe {
                 algebra,
                 dataset: _,
-                base_iri,
+                ..
             } => {
                 let (plan, _) = PlanBuilder::build(dataset.encoder(), &algebra)?;
                 SimplePreparedQueryAction::Describe {

--- a/lib/src/sparql/mod.rs
+++ b/lib/src/sparql/mod.rs
@@ -117,6 +117,7 @@ impl<'a, S: StoreConnection + 'a> SimplePreparedQuery<S> {
         }))
     }
 
+    /// Builds SimplePreparedQuery from an existing `GraphPattern`. This is used to support federated queries via `SERVICE` clauses
     pub(crate) fn new_from_pattern(
         connection: S,
         pattern: &GraphPattern,

--- a/lib/src/sparql/mod.rs
+++ b/lib/src/sparql/mod.rs
@@ -188,6 +188,12 @@ impl<'a> QueryOptions<'a> {
         self.default_graph_as_union = true;
         self
     }
+
+    /// Consider the union of all graphs in the repository as the default graph
+    pub fn with_service_handler(mut self, service_handler: Box<dyn ServiceHandler>) -> Self {
+        self.service_handler = Some(service_handler);
+        self
+    }
 }
 
 /// A parsed [SPARQL query](https://www.w3.org/TR/sparql11-query/)

--- a/lib/src/sparql/model.rs
+++ b/lib/src/sparql/model.rs
@@ -116,7 +116,7 @@ pub struct BindingsIterator<'a> {
 }
 
 impl<'a> BindingsIterator<'a> {
-    pub(crate) fn new(
+    pub fn new(
         variables: Vec<Variable>,
         iter: Box<dyn Iterator<Item = Result<Vec<Option<Term>>>> + 'a>,
     ) -> Self {

--- a/lib/src/sparql/plan.rs
+++ b/lib/src/sparql/plan.rs
@@ -1,4 +1,5 @@
 use crate::sparql::GraphPattern;
+use crate::sparql::model::Variable;
 use crate::sparql::eval::StringOrStoreString;
 use crate::store::numeric_encoder::{
     EncodedQuad, EncodedTerm, Encoder, MemoryStrStore, StrContainer, StrLookup,
@@ -19,6 +20,7 @@ pub enum PlanNode {
     },
     Service {
         service_name: PatternValue,
+        variables: Vec<Variable>,
         child: Box<PlanNode>,
         graph_pattern: GraphPattern,
         silent: bool,

--- a/lib/src/sparql/plan.rs
+++ b/lib/src/sparql/plan.rs
@@ -473,15 +473,13 @@ pub enum TripleTemplateValue {
 pub struct DatasetView<S: StoreConnection> {
     store: S,
     extra: RefCell<MemoryStrStore>,
-    default_graph_as_union: bool,
 }
 
 impl<S: StoreConnection> DatasetView<S> {
-    pub fn new(store: S, default_graph_as_union: bool) -> Self {
+    pub fn new(store: S) -> Self {
         Self {
             store,
             extra: RefCell::new(MemoryStrStore::default()),
-            default_graph_as_union,
         }
     }
 
@@ -491,6 +489,7 @@ impl<S: StoreConnection> DatasetView<S> {
         predicate: Option<EncodedTerm>,
         object: Option<EncodedTerm>,
         graph_name: Option<EncodedTerm>,
+        default_graph_as_union: bool,
     ) -> Box<dyn Iterator<Item = Result<EncodedQuad>> + 'a> {
         if graph_name == None {
             Box::new(
@@ -501,7 +500,7 @@ impl<S: StoreConnection> DatasetView<S> {
                         Ok(quad) => quad.graph_name != ENCODED_DEFAULT_GRAPH,
                     }),
             )
-        } else if graph_name == Some(ENCODED_DEFAULT_GRAPH) && self.default_graph_as_union {
+        } else if graph_name == Some(ENCODED_DEFAULT_GRAPH) && default_graph_as_union {
             Box::new(
                 self.store
                     .quads_for_pattern(subject, predicate, object, None)

--- a/lib/src/sparql/plan.rs
+++ b/lib/src/sparql/plan.rs
@@ -1,3 +1,4 @@
+use crate::sparql::GraphPattern;
 use crate::sparql::eval::StringOrStoreString;
 use crate::store::numeric_encoder::{
     EncodedQuad, EncodedTerm, Encoder, MemoryStrStore, StrContainer, StrLookup,
@@ -15,6 +16,12 @@ pub enum PlanNode {
     Init,
     StaticBindings {
         tuples: Vec<EncodedTuple>,
+    },
+    Service {
+        service_name: PatternValue,
+        child: Box<PlanNode>,
+        graph_pattern: GraphPattern,
+        silent: bool,
     },
     QuadPatternJoin {
         child: Box<PlanNode>,
@@ -161,6 +168,7 @@ impl PlanNode {
                 set.insert(*position);
                 child.add_variables(set);
             }
+            PlanNode::Service { child, .. } => child.add_variables(set),
             PlanNode::Sort { child, .. } => child.add_variables(set),
             PlanNode::HashDeduplicate { child } => child.add_variables(set),
             PlanNode::Skip { child, .. } => child.add_variables(set),

--- a/lib/src/sparql/plan_builder.rs
+++ b/lib/src/sparql/plan_builder.rs
@@ -103,11 +103,16 @@ impl<E: Encoder> PlanBuilder<E> {
                 left: Box::new(self.build_for_graph_pattern(a, variables, graph_name)?),
                 right: Box::new(self.build_for_graph_pattern(b, variables, graph_name)?),
             },
-            GraphPattern::Service(_n, _p, _s) => {
-                return Err(format_err!(
-                    "SPARQL SERVICE clauses are not implemented yet"
-                ))
-            }
+            GraphPattern::Service(n, p, s) => {
+                let service_name = self.pattern_value_from_named_node_or_variable(n, variables)?;
+                let graph_pattern = *p.clone();
+                PlanNode::Service {
+                    service_name,
+                    child: Box::new(self.build_for_graph_pattern(p, variables, service_name)?),
+                    graph_pattern,
+                    silent: *s,
+                }
+            },
             GraphPattern::AggregateJoin(GroupPattern(key, p), aggregates) => {
                 let mut inner_variables = key.clone();
                 let inner_graph_name =

--- a/lib/src/sparql/plan_builder.rs
+++ b/lib/src/sparql/plan_builder.rs
@@ -108,6 +108,7 @@ impl<E: Encoder> PlanBuilder<E> {
                 let graph_pattern = *p.clone();
                 PlanNode::Service {
                     service_name,
+                    variables: variables.clone(),
                     child: Box::new(self.build_for_graph_pattern(p, variables, service_name)?),
                     graph_pattern,
                     silent: *s,

--- a/lib/src/store/memory.rs
+++ b/lib/src/store/memory.rs
@@ -29,8 +29,9 @@ use std::sync::{PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// assert_eq!(vec![quad], results.unwrap());
 ///
 /// // SPARQL query
-/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", QueryOptions::default()).unwrap();
-/// let results = prepared_query.exec().unwrap();
+/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", None).unwrap();
+/// let options = QueryOptions::default();
+/// let results = prepared_query.exec(&options).unwrap();
 /// if let QueryResult::Bindings(results) = results {
 ///     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));
 /// }

--- a/lib/src/store/mod.rs
+++ b/lib/src/store/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod numeric_encoder;
 mod rocksdb;
 
 pub use crate::sparql::GraphPattern;
-pub use crate::store::memory::MemoryRepository;
+pub use crate::store::memory::{MemoryRepository, MemoryRepositoryConnection};
 #[cfg(feature = "rocksdb")]
 pub use crate::store::rocksdb::RocksDbRepository;
 

--- a/lib/src/store/mod.rs
+++ b/lib/src/store/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod numeric_encoder;
 mod rocksdb;
 
 pub use crate::sparql::GraphPattern;
-pub use crate::store::memory::{MemoryRepository, MemoryRepositoryConnection};
+pub use crate::store::memory::MemoryRepository;
 #[cfg(feature = "rocksdb")]
 pub use crate::store::rocksdb::RocksDbRepository;
 

--- a/lib/src/store/mod.rs
+++ b/lib/src/store/mod.rs
@@ -14,7 +14,6 @@ use crate::model::*;
 use crate::sparql::{SimplePreparedQuery};
 use crate::store::numeric_encoder::*;
 use crate::{DatasetSyntax, GraphSyntax, RepositoryConnection, Result};
-use rio_api::iri::Iri;
 use rio_api::parser::{QuadsParser, TriplesParser};
 use rio_turtle::{NQuadsParser, NTriplesParser, TriGParser, TurtleParser};
 use rio_xml::RdfXmlParser;

--- a/lib/src/store/mod.rs
+++ b/lib/src/store/mod.rs
@@ -101,8 +101,9 @@ impl<S: StoreConnection> RepositoryConnection for StoreRepositoryConnection<S> {
     fn prepare_query_from_pattern<'a>(
         &'a self,
         pattern: &GraphPattern,
+        base_iri: Option<&'a str>
     ) -> Result<Self::PreparedQuery> {
-        SimplePreparedQuery::new_from_pattern(self.inner.clone(), pattern) //TODO: avoid clone
+        SimplePreparedQuery::new_from_pattern(self.inner.clone(), pattern, base_iri) //TODO: avoid clone
     }
 
     fn load_graph(

--- a/lib/src/store/mod.rs
+++ b/lib/src/store/mod.rs
@@ -11,9 +11,10 @@ pub use crate::store::memory::MemoryRepository;
 pub use crate::store::rocksdb::RocksDbRepository;
 
 use crate::model::*;
-use crate::sparql::{QueryOptions, SimplePreparedQuery};
+use crate::sparql::{SimplePreparedQuery};
 use crate::store::numeric_encoder::*;
 use crate::{DatasetSyntax, GraphSyntax, RepositoryConnection, Result};
+use rio_api::iri::Iri;
 use rio_api::parser::{QuadsParser, TriplesParser};
 use rio_turtle::{NQuadsParser, NTriplesParser, TriGParser, TurtleParser};
 use rio_xml::RdfXmlParser;
@@ -72,8 +73,8 @@ impl<S: StoreConnection> From<S> for StoreRepositoryConnection<S> {
 impl<S: StoreConnection> RepositoryConnection for StoreRepositoryConnection<S> {
     type PreparedQuery = SimplePreparedQuery<S>;
 
-    fn prepare_query<'a>(&self, query: &str, options: &'a QueryOptions<'a>) -> Result<SimplePreparedQuery<S>> {
-        SimplePreparedQuery::new(self.inner.clone(), query, options) //TODO: avoid clone
+    fn prepare_query<'a>(&self, query: &str, base_iri: Option<&'a str>) -> Result<SimplePreparedQuery<S>> {
+        SimplePreparedQuery::new(self.inner.clone(), query, base_iri) //TODO: avoid clone
     }
 
     fn quads_for_pattern<'a>(
@@ -101,12 +102,9 @@ impl<S: StoreConnection> RepositoryConnection for StoreRepositoryConnection<S> {
     fn prepare_query_from_pattern<'a>(
         &'a self,
         pattern: &GraphPattern,
-        options: &'a QueryOptions<'a>
     ) -> Result<Self::PreparedQuery> {
-        SimplePreparedQuery::new_from_pattern(self.inner.clone(), pattern, options) //TODO: avoid clone
+        SimplePreparedQuery::new_from_pattern(self.inner.clone(), pattern) //TODO: avoid clone
     }
-
-
 
     fn load_graph(
         &mut self,

--- a/lib/src/store/rocksdb.rs
+++ b/lib/src/store/rocksdb.rs
@@ -40,8 +40,9 @@ use std::str;
 /// assert_eq!(vec![quad], results.unwrap());
 ///
 /// // SPARQL query
-/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", QueryOptions::default()).unwrap();
-/// let results = prepared_query.exec().unwrap();
+/// let options = QueryOptions::default();
+/// let prepared_query = connection.prepare_query("SELECT ?s WHERE { ?s ?p ?o }", None).unwrap();
+/// let results = prepared_query.exec(&options).unwrap();
 /// if let QueryResult::Bindings(results) = results {
 ///     assert_eq!(results.into_values_iter().next().unwrap().unwrap()[0], Some(ex.into()));
 /// }

--- a/lib/tests/service_test_cases.rs
+++ b/lib/tests/service_test_cases.rs
@@ -2,86 +2,23 @@ use rudf::model::*;
 use rudf::{GraphSyntax, Repository, RepositoryConnection, MemoryRepository, Result};
 use rudf::sparql::{BindingsIterator, GraphPattern, PreparedQuery, QueryOptions, QueryResult, ServiceHandler};
 use failure::format_err;
+use std::io::BufRead;
 
-fn ex(id: String) -> Term {
-  Term::NamedNode(NamedNode::parse(format!("http://example.com/{}", &id)).unwrap())
-}
 
-fn foaf(id: String) -> Term {
-  Term::NamedNode(NamedNode::parse(format!("http://xmlns.com/foaf/0.1/{}", &id)).unwrap())
-}
-
-fn mailto(id: String) -> Term {
-  Term::NamedNode(NamedNode::parse(format!("mailto:{}", &id)).unwrap())
-}
-
-fn literal(str: String) -> Term {
-  Term::Literal(Literal::new_simple_literal(str))
-}
-
-/*
-#[derive(Clone,Copy)]
-struct SimpleServiceTest;
-impl ServiceHandler for SimpleServiceTest {
-    fn handle<'a>(&'a self, named_node: NamedNode) -> Option<(fn(GraphPattern) -> Result<BindingsIterator<'a>>)> {
-      Some(SimpleServiceTest::handle_service) 
-    }
-}
-
-impl SimpleServiceTest {
-  fn handle_service<'a>(graph_pattern: GraphPattern) -> Result<BindingsIterator<'a>> {
-    let repository = MemoryRepository::default();
-    let mut connection = repository.connection().unwrap();
-    let file = b"<http://example.com/s> <http://example.com/p> <http://example.com/o> .";
-    connection.load_graph(file.as_ref(), GraphSyntax::NTriples, None, None).unwrap();
-    let prepared_query = connection.prepare_query_from_pattern(&graph_pattern, None).unwrap();
-    let result = prepared_query.exec(&Some(SimpleServiceTest)).unwrap();
-    match result {
-      QueryResult::Bindings(iterator) => {
-        let (variables, iter) = iterator.destruct();
-        let cloned_iter = iter.collect::<Vec<_>>().into_iter();
-        let new_iter = BindingsIterator::new(variables, Box::new(cloned_iter));
-        Ok(new_iter)
-      },
-      _ => Err(format_err!("Excpected bindings but got another QueryResult"))
-    }
-  }
-}
-*/
 
 #[test]
 fn simple_service_test() {
 
   struct TestServiceHandler;
   impl ServiceHandler for TestServiceHandler {
-    fn handle<'a>(&'a self, named_node: NamedNode) -> Option<(fn(GraphPattern) -> Result<BindingsIterator<'a>>)> {
+    fn handle<'a>(&'a self, _named_node: NamedNode) -> Option<(fn(GraphPattern) -> Result<BindingsIterator<'a>>)> {
       fn pattern_handler<'a>(graph_pattern: GraphPattern) -> Result<BindingsIterator<'a>> {
-        let repository = MemoryRepository::default();
-        let mut connection = repository.connection().unwrap();
-        let file = b"<http://example.com/s> <http://example.com/p> <http://example.com/o> .";
-        connection.load_graph(file.as_ref(), GraphSyntax::NTriples, None, None).unwrap();
-        let query_options = QueryOptions::default();
-        let prepared_query = connection.prepare_query_from_pattern(&graph_pattern, &query_options).unwrap();
-        let result = prepared_query.exec(&query_options).unwrap();
-        match result {
-          QueryResult::Bindings(iterator) => {
-            let (variables, iter) = iterator.destruct();
-            let cloned_iter = iter.collect::<Vec<_>>().into_iter();
-            let new_iter = BindingsIterator::new(variables, Box::new(cloned_iter));
-            Ok(new_iter)
-          },
-          _ => Err(format_err!("Excpected bindings but got another QueryResult"))
-        }
+        let triples = b"<http://example.com/s> <http://example.com/p> <http://example.com/o> .".as_ref();
+        do_pattern(triples, graph_pattern, QueryOptions::default())
       };
       Some(pattern_handler)
     }
   }
-
-  
-  
-
-  let repository = MemoryRepository::default();
-  let connection = repository.connection().unwrap();
 
   let query = r#"
   SELECT ?s ?p ?o
@@ -91,24 +28,18 @@ fn simple_service_test() {
       { ?s ?p ?o
       }
    }
-  "#;
+  "#.to_string();
 
 
-  let query_options = QueryOptions::default().with_service_handler(Box::new(TestServiceHandler));
-  let prepared_query = connection.prepare_query(query, &query_options).unwrap();
-  let results = prepared_query.exec(&query_options).unwrap();
-  if let QueryResult::Bindings(results) = results {
-    let collected = results.into_values_iter().map(move |b| b.unwrap()).collect::<Vec<_>>();
-    let solution = vec![
+  let options = QueryOptions::default().with_service_handler(Box::new(TestServiceHandler));
+  let results = do_query(b"".as_ref(), query, options).unwrap();
+  let collected = results.into_values_iter().map(move |b| b.unwrap()).collect::<Vec<_>>();
+  let solution = vec![
       vec![ Some(ex(String::from("s"))), Some(ex(String::from("p"))), Some(ex(String::from("o"))) ],
-    ];
-    assert_eq!(collected, solution);
-  } else {
-    assert_eq!(true, false);
-  }
+  ];
+  assert_eq!(collected, solution);
+  
 }
-
-
 
 
 #[test]
@@ -118,12 +49,11 @@ fn two_service_test() {
   struct TwoServiceTest;
   impl ServiceHandler for TwoServiceTest {
       fn handle<'a>(&'a self, named_node: NamedNode) -> Option<(fn(GraphPattern) -> Result<BindingsIterator<'a>>)> {
-          println!("Handler called for {:?}", named_node);   
           let service1 = NamedNode::parse("http://service1.org").unwrap();
           let service2 = NamedNode::parse("http://service2.org").unwrap();
           if named_node == service1 { Some(TwoServiceTest::handle_service1) }
           else if named_node == service2 { Some(TwoServiceTest::handle_service2) }
-          else { None} 
+          else { None } 
       }
   }
 
@@ -131,56 +61,22 @@ fn two_service_test() {
   impl TwoServiceTest {
 
     fn handle_service1<'a>(graph_pattern: GraphPattern) -> Result<BindingsIterator<'a>> {
-      let repository = MemoryRepository::default();
-      let mut connection = repository.connection().unwrap();
-      let file = br#"
+      let triples = br#"
         <http://example.com/bob> <http://xmlns.com/foaf/0.1/name> "Bob" .
         <http://example.com/alice> <http://xmlns.com/foaf/0.1/name> "Alice" .
-        "#;
-      connection.load_graph(file.as_ref(), GraphSyntax::NTriples, None, None).unwrap();
-      let query_options = QueryOptions::default().with_service_handler(Box::new(TwoServiceTest));
-      let prepared_query = connection.prepare_query_from_pattern(&graph_pattern, &query_options).unwrap();
-      let result = prepared_query.exec(&query_options).unwrap();
-      match result {
-        QueryResult::Bindings(iterator) => {
-          let (variables, iter) = iterator.destruct();
-          let cloned_iter = iter.collect::<Vec<_>>().into_iter();
-          let new_iter = BindingsIterator::new(variables, Box::new(cloned_iter));
-          Ok(new_iter)
-        },
-        _ => Err(format_err!("Excpected bindings but got another QueryResult"))
-      }
+        "#.as_ref();
+      do_pattern(triples, graph_pattern, QueryOptions::default())
     }
 
-
-
-
     fn handle_service2<'a>(graph_pattern: GraphPattern) -> Result<BindingsIterator<'a>> {
-      let repository = MemoryRepository::default();
-      let mut connection = repository.connection().unwrap();
-      let file = br#"
+      let triples = br#"
         <http://example.com/bob> <http://xmlns.com/foaf/0.1/mbox> <mailto:bob@example.com> .
         <http://example.com/alice> <http://xmlns.com/foaf/0.1/mbox> <mailto:alice@example.com> .
-        "#;
-      connection.load_graph(file.as_ref(), GraphSyntax::NTriples, None, None).unwrap();
-      let query_options = QueryOptions::default().with_service_handler(Box::new(TwoServiceTest));
-      let prepared_query = connection.prepare_query_from_pattern(&graph_pattern, &query_options).unwrap();
-      let result = prepared_query.exec(&query_options).unwrap();
-      match result {
-        QueryResult::Bindings(iterator) => {
-          let (variables, iter) = iterator.destruct();
-          let cloned_iter = iter.collect::<Vec<_>>().into_iter();
-          let new_iter = BindingsIterator::new(variables, Box::new(cloned_iter));
-          Ok(new_iter)
-        },
-        _ => Err(format_err!("Excpected bindings but got another QueryResult"))
-      }
+        "#.as_ref();
+      do_pattern(triples, graph_pattern, QueryOptions::default())
     }
 
   }
-
-  let repository = MemoryRepository::default();
-  let connection = repository.connection().unwrap();
 
   let query = r#"
   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -196,26 +92,74 @@ fn two_service_test() {
       }
     }
   ORDER BY ?name
-  "#;
+  "#.to_string();
 
-  let query_options = QueryOptions::default().with_service_handler(Box::new(TwoServiceTest));
-  let prepared_query = connection.prepare_query(query, &query_options).unwrap();
-  let results = prepared_query.exec(&query_options).unwrap();
-  if let QueryResult::Bindings(results) = results {
-    let collected = results.into_values_iter().map(move |b| b.unwrap()).collect::<Vec<_>>();
-    for c in collected.clone() {
-      println!("{:?}", c);
-    }
-    println!("\n\n\n");
-    let solution = vec![
+  let options = QueryOptions::default().with_service_handler(Box::new(TwoServiceTest));
+  let results = do_query(b"".as_ref(), query, options).unwrap();
+  let collected = results.into_values_iter().map(move |b| b.unwrap()).collect::<Vec<_>>();
+  let solution = vec![
       vec![ Some(literal("Alice".to_string())), Some(mailto("alice@example.com".to_string())) ],
       vec![ Some(literal("Bob".to_string())), Some(mailto("bob@example.com".to_string())) ],
     ];
-    println!("Results: {:?}", collected);
-    assert_eq!(collected, solution);
-  } else {
-    assert_eq!(true, false);
+  assert_eq!(collected, solution);
+}
+
+fn ex(id: String) -> Term {
+  Term::NamedNode(NamedNode::parse(format!("http://example.com/{}", &id)).unwrap())
+}
+
+fn mailto(id: String) -> Term {
+  Term::NamedNode(NamedNode::parse(format!("mailto:{}", &id)).unwrap())
+}
+
+fn literal(str: String) -> Term {
+  Term::Literal(Literal::new_simple_literal(str))
+}
+
+fn make_repository(reader: impl BufRead) -> Result<MemoryRepository> {
+  let repository = MemoryRepository::default();
+  let mut connection = repository.connection()?;
+  connection.load_graph(reader, GraphSyntax::NTriples, None, None).unwrap();
+  Ok(repository)
+}
+
+fn query_repository<'a>(repository: MemoryRepository, query: String, options: QueryOptions<'a>) -> Result<BindingsIterator<'a>> {
+  let connection = repository.connection()?;
+  let prepared_query = connection.prepare_query(&query, &options)?;
+  let result = prepared_query.exec(&options)?;
+  match result {
+    QueryResult::Bindings(iterator) => {
+      let (varaibles, iter) = iterator.destruct();
+      let collected = iter.collect::<Vec<_>>();
+      Ok(BindingsIterator::new(varaibles, Box::new(collected.into_iter())))
+    },
+    _ => Err(format_err!("Excpected bindings but got another QueryResult"))
+  }
+} 
+
+//fn pattern_repository<'a>(repository: MemoryRepository, pattern: GraphPattern, options: QueryOptions<'a>) -> Result<Vec<Vec<Option<Term>>>> {
+fn pattern_repository<'a>(repository: MemoryRepository, pattern: GraphPattern, options: QueryOptions<'a>) -> Result<BindingsIterator<'a>> {
+  let connection = repository.connection()?;
+  let prepared_query = connection.prepare_query_from_pattern(&pattern, &options)?;
+  let result = prepared_query.exec(&options)?;
+  match result {
+    QueryResult::Bindings(iterator) => {
+      let (varaibles, iter) = iterator.destruct();
+      let collected = iter.collect::<Vec<_>>();
+      Ok(BindingsIterator::new(varaibles, Box::new(collected.into_iter())))
+    }
+    _ => Err(format_err!("Excpected bindings but got another QueryResult"))
   }
 }
 
+//fn do_query<'a>(reader: impl BufRead, query: String, options: QueryOptions<'a>) -> Result<Vec<Vec<Option<Term>>>> {
+fn do_query<'a>(reader: impl BufRead, query: String, options: QueryOptions<'a>) -> Result<BindingsIterator<'a>> {
+  let repository = make_repository(reader)?;
+  query_repository(repository, query, options)
+}
 
+//fn do_pattern<'a>(reader: impl BufRead, pattern: GraphPattern, options: QueryOptions<'a>) -> Result<Vec<Vec<Option<Term>>>> {
+fn do_pattern<'a>(reader: impl BufRead, pattern: GraphPattern, options: QueryOptions<'a>) -> Result<BindingsIterator<'a>> {
+  let repository = make_repository(reader)?;
+  pattern_repository(repository, pattern, options)
+}

--- a/lib/tests/service_test_cases.rs
+++ b/lib/tests/service_test_cases.rs
@@ -110,7 +110,7 @@ fn silent_service_test() {
   #[derive(Clone,Copy)]
   struct TwoServiceTest;
   impl ServiceHandler for TwoServiceTest {
-      fn handle<'a>(&'a self, named_node: NamedNode) -> Option<(fn(GraphPattern) -> Result<BindingsIterator<'a>>)> {
+      fn handle<'a>(&'a self, _named_node: NamedNode) -> Option<(fn(GraphPattern) -> Result<BindingsIterator<'a>>)> {
          Some(TwoServiceTest::handle_service) 
       }
   }
@@ -174,7 +174,7 @@ fn make_repository(reader: impl BufRead) -> Result<MemoryRepository> {
 
 fn query_repository<'a>(repository: MemoryRepository, query: String, options: QueryOptions<'a>) -> Result<BindingsIterator<'a>> {
   let connection = repository.connection()?;
-  let prepared_query = connection.prepare_query(&query, &options)?;
+  let prepared_query = connection.prepare_query(&query, None)?;
   let result = prepared_query.exec(&options)?;
   match result {
     QueryResult::Bindings(iterator) => {
@@ -186,10 +186,9 @@ fn query_repository<'a>(repository: MemoryRepository, query: String, options: Qu
   }
 } 
 
-//fn pattern_repository<'a>(repository: MemoryRepository, pattern: GraphPattern, options: QueryOptions<'a>) -> Result<Vec<Vec<Option<Term>>>> {
 fn pattern_repository<'a>(repository: MemoryRepository, pattern: GraphPattern, options: QueryOptions<'a>) -> Result<BindingsIterator<'a>> {
   let connection = repository.connection()?;
-  let prepared_query = connection.prepare_query_from_pattern(&pattern, &options)?;
+  let prepared_query = connection.prepare_query_from_pattern(&pattern)?;
   let result = prepared_query.exec(&options)?;
   match result {
     QueryResult::Bindings(iterator) => {
@@ -201,13 +200,11 @@ fn pattern_repository<'a>(repository: MemoryRepository, pattern: GraphPattern, o
   }
 }
 
-//fn do_query<'a>(reader: impl BufRead, query: String, options: QueryOptions<'a>) -> Result<Vec<Vec<Option<Term>>>> {
 fn do_query<'a>(reader: impl BufRead, query: String, options: QueryOptions<'a>) -> Result<BindingsIterator<'a>> {
   let repository = make_repository(reader)?;
   query_repository(repository, query, options)
 }
 
-//fn do_pattern<'a>(reader: impl BufRead, pattern: GraphPattern, options: QueryOptions<'a>) -> Result<Vec<Vec<Option<Term>>>> {
 fn do_pattern<'a>(reader: impl BufRead, pattern: GraphPattern, options: QueryOptions<'a>) -> Result<BindingsIterator<'a>> {
   let repository = make_repository(reader)?;
   pattern_repository(repository, pattern, options)

--- a/lib/tests/service_test_cases.rs
+++ b/lib/tests/service_test_cases.rs
@@ -217,7 +217,7 @@ fn query_repository<'a>(repository: MemoryRepository, query: String, options: Qu
 
 fn pattern_repository<'a>(repository: MemoryRepository, pattern: GraphPattern, options: QueryOptions<'a>) -> Result<BindingsIterator<'a>> {
   let connection = repository.connection()?;
-  let prepared_query = connection.prepare_query_from_pattern(&pattern)?;
+  let prepared_query = connection.prepare_query_from_pattern(&pattern, None)?;
   let result = prepared_query.exec(&options)?;
   match result {
     QueryResult::Bindings(iterator) => {

--- a/lib/tests/service_test_cases.rs
+++ b/lib/tests/service_test_cases.rs
@@ -1,0 +1,217 @@
+use rudf::model::*;
+use rudf::{GraphSyntax, Repository, RepositoryConnection, MemoryRepository, Result};
+use rudf::sparql::{BindingsIterator, GraphPattern, PreparedQuery, QueryOptions, QueryResult, ServiceHandler};
+use failure::format_err;
+
+fn ex(id: String) -> Term {
+  Term::NamedNode(NamedNode::parse(format!("http://example.com/{}", &id)).unwrap())
+}
+
+fn foaf(id: String) -> Term {
+  Term::NamedNode(NamedNode::parse(format!("http://xmlns.com/foaf/0.1/{}", &id)).unwrap())
+}
+
+fn mailto(id: String) -> Term {
+  Term::NamedNode(NamedNode::parse(format!("mailto:{}", &id)).unwrap())
+}
+
+fn literal(str: String) -> Term {
+  Term::Literal(Literal::new_simple_literal(str))
+}
+
+/*
+#[derive(Clone,Copy)]
+struct SimpleServiceTest;
+impl ServiceHandler for SimpleServiceTest {
+    fn handle<'a>(&'a self, named_node: NamedNode) -> Option<(fn(GraphPattern) -> Result<BindingsIterator<'a>>)> {
+      Some(SimpleServiceTest::handle_service) 
+    }
+}
+
+impl SimpleServiceTest {
+  fn handle_service<'a>(graph_pattern: GraphPattern) -> Result<BindingsIterator<'a>> {
+    let repository = MemoryRepository::default();
+    let mut connection = repository.connection().unwrap();
+    let file = b"<http://example.com/s> <http://example.com/p> <http://example.com/o> .";
+    connection.load_graph(file.as_ref(), GraphSyntax::NTriples, None, None).unwrap();
+    let prepared_query = connection.prepare_query_from_pattern(&graph_pattern, None).unwrap();
+    let result = prepared_query.exec(&Some(SimpleServiceTest)).unwrap();
+    match result {
+      QueryResult::Bindings(iterator) => {
+        let (variables, iter) = iterator.destruct();
+        let cloned_iter = iter.collect::<Vec<_>>().into_iter();
+        let new_iter = BindingsIterator::new(variables, Box::new(cloned_iter));
+        Ok(new_iter)
+      },
+      _ => Err(format_err!("Excpected bindings but got another QueryResult"))
+    }
+  }
+}
+*/
+
+#[test]
+fn simple_service_test() {
+
+  struct TestServiceHandler;
+  impl ServiceHandler for TestServiceHandler {
+    fn handle<'a>(&'a self, named_node: NamedNode) -> Option<(fn(GraphPattern) -> Result<BindingsIterator<'a>>)> {
+      fn pattern_handler<'a>(graph_pattern: GraphPattern) -> Result<BindingsIterator<'a>> {
+        let repository = MemoryRepository::default();
+        let mut connection = repository.connection().unwrap();
+        let file = b"<http://example.com/s> <http://example.com/p> <http://example.com/o> .";
+        connection.load_graph(file.as_ref(), GraphSyntax::NTriples, None, None).unwrap();
+        let query_options = QueryOptions::default();
+        let prepared_query = connection.prepare_query_from_pattern(&graph_pattern, &query_options).unwrap();
+        let result = prepared_query.exec(&query_options).unwrap();
+        match result {
+          QueryResult::Bindings(iterator) => {
+            let (variables, iter) = iterator.destruct();
+            let cloned_iter = iter.collect::<Vec<_>>().into_iter();
+            let new_iter = BindingsIterator::new(variables, Box::new(cloned_iter));
+            Ok(new_iter)
+          },
+          _ => Err(format_err!("Excpected bindings but got another QueryResult"))
+        }
+      };
+      Some(pattern_handler)
+    }
+  }
+
+  
+  
+
+  let repository = MemoryRepository::default();
+  let connection = repository.connection().unwrap();
+
+  let query = r#"
+  SELECT ?s ?p ?o
+  WHERE
+    { 
+      SERVICE <http://service1.org>
+      { ?s ?p ?o
+      }
+   }
+  "#;
+
+
+  let query_options = QueryOptions::default();
+  let prepared_query = connection.prepare_query(query, &query_options).unwrap();
+  let results = prepared_query.exec(&query_options).unwrap();
+  if let QueryResult::Bindings(results) = results {
+    let collected = results.into_values_iter().map(move |b| b.unwrap()).collect::<Vec<_>>();
+    let solution = vec![
+      vec![ Some(ex(String::from("s"))), Some(ex(String::from("p"))), Some(ex(String::from("o"))) ],
+    ];
+    assert_eq!(collected, solution);
+  } else {
+    assert_eq!(true, false);
+  }
+}
+/*
+#[derive(Clone,Copy)]
+struct TwoServiceTest;
+impl ServiceHandler for TwoServiceTest {
+    fn handle<'a>(&'a self, named_node: NamedNode) -> Option<(fn(GraphPattern) -> Result<BindingsIterator<'a>>)> {
+        println!("Handler called for {:?}", named_node);   
+        let service1 = NamedNode::parse("http://service1.org").unwrap();
+        let service2 = NamedNode::parse("http://service2.org").unwrap();
+        if named_node == service1 { Some(TwoServiceTest::handle_service1) }
+        else if named_node == service2 { Some(TwoServiceTest::handle_service2) }
+        else { None} 
+    }
+}
+
+
+impl TwoServiceTest {
+
+  fn handle_service1<'a>(graph_pattern: GraphPattern) -> Result<BindingsIterator<'a>> {
+    let repository = MemoryRepository::default();
+    let mut connection = repository.connection().unwrap();
+    let file = br#"
+      <http://example.com/bob> <http://xmlns.com/foaf/0.1/name> "Bob" .
+      <http://example.com/alice> <http://xmlns.com/foaf/0.1/name> "Alice" .
+      "#;
+    connection.load_graph(file.as_ref(), GraphSyntax::NTriples, None, None).unwrap();
+    let prepared_query = connection.prepare_query_from_pattern(&graph_pattern, None).unwrap();
+    let result = prepared_query.exec(&Some(NoneService)).unwrap();
+    match result {
+      QueryResult::Bindings(iterator) => {
+        let (variables, iter) = iterator.destruct();
+        let cloned_iter = iter.collect::<Vec<_>>().into_iter();
+        let new_iter = BindingsIterator::new(variables, Box::new(cloned_iter));
+        Ok(new_iter)
+      },
+      _ => Err(format_err!("Excpected bindings but got another QueryResult"))
+    }
+  }
+
+
+
+
+  fn handle_service2<'a>(graph_pattern: GraphPattern) -> Result<BindingsIterator<'a>> {
+    let repository = MemoryRepository::default();
+    let mut connection = repository.connection().unwrap();
+    let file = br#"
+      <http://example.com/bob> <http://xmlns.com/foaf/0.1/mbox> <mailto:bob@example.com> .
+      <http://example.com/alice> <http://xmlns.com/foaf/0.1/mbox> <mailto:alice@example.com> .
+      "#;
+    connection.load_graph(file.as_ref(), GraphSyntax::NTriples, None, None).unwrap();
+    let prepared_query = connection.prepare_query_from_pattern(&graph_pattern, None).unwrap();
+    let result = prepared_query.exec(&Some(NoneService)).unwrap();
+    match result {
+      QueryResult::Bindings(iterator) => {
+        let (variables, iter) = iterator.destruct();
+        let cloned_iter = iter.collect::<Vec<_>>().into_iter();
+        let new_iter = BindingsIterator::new(variables, Box::new(cloned_iter));
+        Ok(new_iter)
+      },
+      _ => Err(format_err!("Excpected bindings but got another QueryResult"))
+    }
+  }
+
+}
+
+
+#[test]
+fn two_service_test() {
+  let repository = MemoryRepository::default();
+  let connection = repository.connection().unwrap();
+
+  let query = r#"
+  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+  SELECT ?name ?mbox 
+  WHERE
+    { 
+      SERVICE <http://service1.org>
+      { ?s foaf:name ?name
+      }
+
+      SERVICE <http://service2.org>
+      { ?s foaf:mbox ?mbox
+      }
+    }
+  ORDER BY ?name
+  "#;
+
+  let prepared_query = connection.prepare_query(query, None).unwrap();
+  let service_handler = Some(TwoServiceTest);
+  let results = prepared_query.exec(&service_handler).unwrap();
+  if let QueryResult::Bindings(results) = results {
+    let collected = results.into_values_iter().map(move |b| b.unwrap()).collect::<Vec<_>>();
+    for c in collected.clone() {
+      println!("{:?}", c);
+    }
+    println!("\n\n\n");
+    let solution = vec![
+      vec![ Some(literal("Alice".to_string())), Some(mailto("alice@example.com".to_string())) ],
+      vec![ Some(literal("Bob".to_string())), Some(mailto("bob@example.com".to_string())) ],
+    ];
+    println!("Results: {:?}", collected);
+    assert_eq!(collected, solution);
+  } else {
+    assert_eq!(true, false);
+  }
+}
+*/
+
+

--- a/lib/tests/sparql_test_cases.rs
+++ b/lib/tests/sparql_test_cases.rs
@@ -158,7 +158,7 @@ fn sparql_w3c_query_evaluation_testsuite() -> Result<()> {
             }
             match repository
                 .connection()?
-                .prepare_query(&read_file_to_string(&test.query)?, &QueryOptions::default().with_base_iri(&test.query))
+                .prepare_query(&read_file_to_string(&test.query)?, None)
             {
                 Err(error) => Err(format_err!(
                     "Failure to parse query of {} with error: {}",

--- a/lib/tests/sparql_test_cases.rs
+++ b/lib/tests/sparql_test_cases.rs
@@ -164,7 +164,7 @@ fn sparql_w3c_query_evaluation_testsuite() -> Result<()> {
                     "Failure to parse query of {} with error: {}",
                     test, error
                 )),
-                Ok(query) => match query.exec(&QueryOptions::default().with_base_iri(&test.query)) {
+                Ok(query) => match query.exec(&QueryOptions::default()) {
                     Err(error) => Err(format_err!(
                         "Failure to execute query of {} with error: {}",
                         test, error

--- a/lib/tests/sparql_test_cases.rs
+++ b/lib/tests/sparql_test_cases.rs
@@ -158,13 +158,13 @@ fn sparql_w3c_query_evaluation_testsuite() -> Result<()> {
             }
             match repository
                 .connection()?
-                .prepare_query(&read_file_to_string(&test.query)?, None)
+                .prepare_query(&read_file_to_string(&test.query)?, Some(&test.query))
             {
                 Err(error) => Err(format_err!(
                     "Failure to parse query of {} with error: {}",
                     test, error
                 )),
-                Ok(query) => match query.exec(&QueryOptions::default()) {
+                Ok(query) => match query.exec(&QueryOptions::default().with_base_iri(&test.query)) {
                     Err(error) => Err(format_err!(
                         "Failure to execute query of {} with error: {}",
                         test, error

--- a/lib/tests/sparql_test_cases.rs
+++ b/lib/tests/sparql_test_cases.rs
@@ -158,13 +158,13 @@ fn sparql_w3c_query_evaluation_testsuite() -> Result<()> {
             }
             match repository
                 .connection()?
-                .prepare_query(&read_file_to_string(&test.query)?, QueryOptions::default().with_base_iri(&test.query))
+                .prepare_query(&read_file_to_string(&test.query)?, &QueryOptions::default().with_base_iri(&test.query))
             {
                 Err(error) => Err(format_err!(
                     "Failure to parse query of {} with error: {}",
                     test, error
                 )),
-                Ok(query) => match query.exec() {
+                Ok(query) => match query.exec(&QueryOptions::default()) {
                     Err(error) => Err(format_err!(
                         "Failure to execute query of {} with error: {}",
                         test, error

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -148,9 +148,10 @@ fn evaluate_sparql_query<R: RepositoryConnection>(
     request: &Request,
 ) -> Response {
     //TODO: stream
-    match connection.prepare_query(query, QueryOptions::default()) {
+    let options = QueryOptions::default();
+    match connection.prepare_query(query, None) {
         Ok(query) => {
-            let results = query.exec().unwrap();
+            let results = query.exec(&options).unwrap();
             if let QueryResult::Graph(_) = results {
                 let supported_formats = [
                     GraphSyntax::NTriples.media_type(),


### PR DESCRIPTION
This is working! There are tests in the lib/tests folder. The one thing to note is that I found storing `QueryOptions` in `SimpleEvaluator` problematic because a lifetime variable needed to be threaded through all of the types. I moved it to be a parameter to `PreparedQuery::exec`, and returned `base_iri` as a parameter to `SimpleEvaluator::new`, but it can be overridden with the `QueryOptions` passed to `PreparedQuery::exec`. I also incorporated all of the feedback from your previous comments. Let me know if you have any feedback